### PR TITLE
Migrate to modern error handling and Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["COM", "interop", "safearray", "variant"]
 categories = ["api-bindings", "development-tools::ffi", "os::windows-apis"]
 documentation = "https://docs.rs/oaidl/0.2.1/x86_64-pc-windows-msvc/oaidl/"
+edition = "2018"
 
 [dependencies]
 # mandatory packages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ widestring = "0.4.0"
 winapi = {version = "0.3.6", features = ["minwindef", "ntdef", "oaidl", "oleauto", "unknwnbase", "wtypes"]}
 failure = "0.1.2"
 
-# Optional packages 
+# Optional packages
 serde = {version = "1.0", optional = true, features = ["derive"]}
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/oaidl/0.2.1/x86_64-pc-windows-msvc/oaidl/"
 rust_decimal = "0.10.1"
 widestring = "0.4.0"
 winapi = {version = "0.3.6", features = ["minwindef", "ntdef", "oaidl", "oleauto", "unknwnbase", "wtypes"]}
-failure = "0.1.2"
+thiserror = "1"
 
 # Optional packages
 serde = {version = "1.0", optional = true, features = ["derive"]}

--- a/src/array.rs
+++ b/src/array.rs
@@ -285,12 +285,12 @@ impl SafeArrayElement for U16String {
 }
 impl_safe_arr_elem!(
     #[doc="`SafeArrayElement` impl for ['SCode']. This allows it to be converted into SAFEARRAY with vt = `VT_ERROR`."]
-    SCode => SCODE, 
+    SCode => SCODE,
     VT_ERROR
 );
 impl_safe_arr_elem!(
     #[doc="`SafeArrayElement` impl for ['VariantBool']. This allows it to be converted into SAFEARRAY with vt = `VT_BOOL`."]
-    VariantBool => VARIANT_BOOL, 
+    VariantBool => VARIANT_BOOL,
     VT_BOOL
 );
 
@@ -350,7 +350,7 @@ impl SafeArrayElement for Box<VariantWrapper> {
 
 impl_safe_arr_elem!(
     #[doc="`SafeArrayElement` impl for ['DecWrapper']. This allows it to be converted into SAFEARRAY with vt = `VT_DECIMAL`."]
-    DecWrapper => DECIMAL, 
+    DecWrapper => DECIMAL,
     VT_DECIMAL
 );
 //VT_RECORD
@@ -376,12 +376,12 @@ impl_safe_arr_elem!(
 );
 impl_safe_arr_elem!(
     #[doc="`SafeArrayElement` impl for [`Int`]. This allows it to be converted into SAFEARRAY with vt = `VT_INT`."]
-    Int => i32, 
+    Int => i32,
     VT_INT
 );
 impl_safe_arr_elem!(
     #[doc="`SafeArrayElement` impl for [`UInt`]. This allows it to be converted into SAFEARRAY with vt = `VT_INT`."]
-    UInt => u32, 
+    UInt => u32,
     VT_UINT
 );
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -333,7 +333,7 @@ impl SafeArrayElement for Variants {
         <Self as SafeArrayPtrElement>::into_safearray(self, psa, ix)
     }
 }
-impl SafeArrayElement for Box<VariantWrapper> {
+impl SafeArrayElement for Box<dyn VariantWrapper> {
     const SFTYPE: u32 = VT_VARIANT;
     type Element = Ptr<VARIANT, VariantDestructor>;
 
@@ -517,7 +517,7 @@ where
         assert!(!psa.is_null());
         let psa: Ptr<SAFEARRAY, SafeArrayDestructor> = Ptr::with_checked(psa).unwrap();
 
-        for (ix, mut elem) in self.enumerate() {
+        for (ix, elem) in self.enumerate() {
             match <Itr::Item as SafeArrayElement>::into_safearray(elem, psa.as_ptr(), ix as i32) {
                 Ok(()) => continue,
                 //Safe-ish to do because memory allocated will be freed.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -69,7 +69,7 @@ pub enum IntoSafeArrElemError {
     #[fail(display = "{}", _0)]
     BStringFailed(Box<BStringError>),
     /// `SafeArrayPutElement` failed with `HRESULT`
-    #[fail(display = "SafeArrayPutElement failed with HRESULT = 0x{}", hr)]
+    #[fail(display = "SafeArrayPutElement failed with HRESULT = 0x{:x}", hr)]
     PutElementFailed {
         /// HRESULT returned by SafeArrayPutElement call
         hr: i32,
@@ -147,19 +147,19 @@ pub enum FromSafeArrayError {
         found: u32,
     },
     /// Call to SafeArrayGetLBound failed
-    #[fail(display = "SafeArrayGetLBound failed with HRESULT = 0x{}", hr)]
+    #[fail(display = "SafeArrayGetLBound failed with HRESULT = 0x{:x}", hr)]
     SafeArrayLBoundFailed {
         /// HRESULT returned
         hr: i32,
     },
     /// Call to SafeArrayGetRBound failed
-    #[fail(display = "SafeArrayGetRBound failed with HRESULT = 0x{}", hr)]
+    #[fail(display = "SafeArrayGetRBound failed with HRESULT = 0x{:x}", hr)]
     SafeArrayRBoundFailed {
         /// HRESULT returned
         hr: i32,
     },
     /// Call to SafeArrayGetVartype failed
-    #[fail(display = "SafeArrayGetVartype failed with HRESULT = 0x{}", hr)]
+    #[fail(display = "SafeArrayGetVartype failed with HRESULT = 0x{:x}", hr)]
     SafeArrayGetVartypeFailed {
         /// HRESULT returned
         hr: i32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,8 +95,7 @@
 //! [`SafeArrayExt`]: trait.SafeArrayExt.html
 //! [`VariantExt`]: trait.VariantExt.html
 
-#[macro_use]
-extern crate failure;
+extern crate thiserror;
 
 extern crate rust_decimal;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,17 +95,9 @@
 //! [`SafeArrayExt`]: trait.SafeArrayExt.html
 //! [`VariantExt`]: trait.VariantExt.html
 
-extern crate thiserror;
-
-extern crate rust_decimal;
-
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
-
-extern crate widestring;
-
-extern crate winapi;
 
 mod array;
 mod bstr;

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -8,93 +8,97 @@ pub trait PtrDestructor<T> {
     fn drop(ptr: NonNull<T>);
 }
 
-/// Default destructor that does not free the memory. 
+/// Default destructor that does not free the memory.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd)]
 pub struct DefaultDestructor;
-impl<T> PtrDestructor<T> for DefaultDestructor 
-{
-    /// This impl *will* leak the `*mut T`. 
+impl<T> PtrDestructor<T> for DefaultDestructor {
+    /// This impl *will* leak the `*mut T`.
     fn drop(_ptr: NonNull<T>) {}
 }
 
-/// Automatically frees the memory pointed to by `Ptr<T>`. 
-/// Uses `std::ptr::drop_in_place` to drop T generically. 
+/// Automatically frees the memory pointed to by `Ptr<T>`.
+/// Uses `std::ptr::drop_in_place` to drop T generically.
 /// This isn't desirable in all situations however.  
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd)]
 pub struct DropDestructor;
-impl<T> PtrDestructor<T> for DropDestructor 
-{
-    /// 
+impl<T> PtrDestructor<T> for DropDestructor {
+    ///
     fn drop(ptr: NonNull<T>) {
         let p: *mut T = ptr.as_ptr();
         drop(ptr);
-        unsafe {drop_in_place(p)};
+        unsafe { drop_in_place(p) };
     }
 }
 
 /// Convenience type for holding value of `*mut T`.
 /// Mostly just a projection of [`NonNull<T>`] functionality.
-/// 
+///
 /// ## Invariants
-/// 
-/// `*mut T` is guaranteed to be NonNull. 
-/// 
+///
+/// `*mut T` is guaranteed to be NonNull.
+///
 /// ## Memory Safety
-/// 
-/// The default destructor will not drop the *mut T. Therefore, 
-/// when the `Ptr<T>` is dropped, the memory will be leaked. 
-/// 
+///
+/// The default destructor will not drop the *mut T. Therefore,
+/// when the `Ptr<T>` is dropped, the memory will be leaked.
+///
 /// Use `DropDestructor` if you want to drop the *mut T in the standard way.  
 #[derive(Debug, Eq, Hash, PartialOrd, PartialEq)]
-pub struct Ptr<T, D = DefaultDestructor> 
+pub struct Ptr<T, D = DefaultDestructor>
 where
-    D: PtrDestructor<T>
+    D: PtrDestructor<T>,
 {
-    inner: Option<NonNull<T>>, 
-    _marker: PhantomData<D>
+    inner: Option<NonNull<T>>,
+    _marker: PhantomData<D>,
 }
 
 impl<T: Clone> Clone for Ptr<T> {
-    /// This impl *will* allocate a new T. This is because cloning a 
+    /// This impl *will* allocate a new T. This is because cloning a
     /// raw ptr only copies the pointer itself, so the memory location
     /// is the same. This creates issues when you set up drop glue on your Ptr<T>
-    /// values. 
+    /// values.
     fn clone(&self) -> Self {
         let p = match &self.inner {
-            Some(ref nn) => nn.as_ptr(), 
-            None => unreachable!()
+            Some(ref nn) => nn.as_ptr(),
+            None => unreachable!(),
         };
-        let cloned_t = Box::into_raw(Box::new(unsafe {(*p).clone()}));
-        Ptr {inner: Some(unsafe {NonNull::new_unchecked(cloned_t)}), _marker: PhantomData}
+        let cloned_t = Box::into_raw(Box::new(unsafe { (*p).clone() }));
+        Ptr {
+            inner: Some(unsafe { NonNull::new_unchecked(cloned_t) }),
+            _marker: PhantomData,
+        }
     }
 }
 
-impl<T, D> Drop for Ptr<T, D> 
+impl<T, D> Drop for Ptr<T, D>
 where
-    D: PtrDestructor<T> 
+    D: PtrDestructor<T>,
 {
-    fn drop(&mut self){
+    fn drop(&mut self) {
         if let Some(nn) = self.inner.take() {
             D::drop(nn)
         }
     }
 }
 
-impl<T, D> Ptr<T, D> 
+impl<T, D> Ptr<T, D>
 where
-    D: PtrDestructor<T>
+    D: PtrDestructor<T>,
 {
-    /// Wraps a valid [`NonNull<T>`] 
+    /// Wraps a valid [`NonNull<T>`]
     /// [`NonNull<T>`]: https://doc.rust-lang.org/nightly/core/ptr/struct.NonNull.html
     pub fn new(p: NonNull<T>) -> Ptr<T, D> {
-        Ptr { inner: Some(p), _marker: PhantomData }
+        Ptr {
+            inner: Some(p),
+            _marker: PhantomData,
+        }
     }
 
     /// Checks a `*mut T` for null and wraps it up for easier handling.
     pub fn with_checked(p: *mut T) -> Option<Ptr<T, D>> {
         match NonNull::new(p) {
             Some(p) => Some(Ptr::new(p)),
-            None => None
+            None => None,
         }
     }
 
@@ -109,15 +113,15 @@ where
         }
     }
 
-    /// Get inner reference. 
-    /// 
+    /// Get inner reference.
+    ///
     /// ## Safety
-    /// 
-    /// The underlying `.as_ref` call is unsafe so this is unsafe as well, 
+    ///
+    /// The underlying `.as_ref` call is unsafe so this is unsafe as well,
     /// in order to propagate the unsafety invariant forward.
-    /// 
-    /// The lifetime of the provided reference is tied to self. 
-    /// 
+    ///
+    /// The lifetime of the provided reference is tied to self.
+    ///
     /// If you need an unbound lifetime, use `&*my_ptr.as_ptr()` instead.
     pub unsafe fn as_ref(&self) -> &T {
         if let Some(ref nn) = &self.inner {
@@ -129,15 +133,15 @@ where
         }
     }
 
-    /// Get inner mutable reference. 
-    /// 
+    /// Get inner mutable reference.
+    ///
     /// ## Safety
-    /// 
-    /// The underlying `.as_ref` call is unsafe so this is unsafe as well, 
+    ///
+    /// The underlying `.as_ref` call is unsafe so this is unsafe as well,
     /// in order to propagate the unsafety invariant forward.
-    /// 
-    /// The lifetime of the provided reference is tied to self. 
-    /// 
+    ///
+    /// The lifetime of the provided reference is tied to self.
+    ///
     /// If you need an unbound lifetime, use `&mut *my_ptr.as_ptr()` instead.
     pub unsafe fn as_mut(&mut self) -> &mut T {
         if let Some(ref mut nn) = &mut self.inner {
@@ -149,11 +153,11 @@ where
         }
     }
 
-    /// Cast a `Ptr<T, D>` to `Ptr<U, Q>`. 
-    /// Whatever the `D` is here, the `T` will not be dropped. 
-    pub fn cast<U, Q>(mut self) -> Ptr<U, Q> 
+    /// Cast a `Ptr<T, D>` to `Ptr<U, Q>`.
+    /// Whatever the `D` is here, the `T` will not be dropped.
+    pub fn cast<U, Q>(mut self) -> Ptr<U, Q>
     where
-        Q: PtrDestructor<U>
+        Q: PtrDestructor<U>,
     {
         // We take here so as to ensure the T isn't dropped
         if let Some(nn) = self.inner.take() {
@@ -177,11 +181,11 @@ impl<T> fmt::Pointer for Ptr<T> {
     }
 }
 
-impl<T, D> From<NonNull<T>> for Ptr<T, D> 
+impl<T, D> From<NonNull<T>> for Ptr<T, D>
 where
-    D: PtrDestructor<T>
+    D: PtrDestructor<T>,
 {
-    /// Free, zero-allocation conversion from [`NonNull<T>`] 
+    /// Free, zero-allocation conversion from [`NonNull<T>`]
     fn from(nn: NonNull<T>) -> Self {
         Ptr::new(nn)
     }
@@ -190,7 +194,7 @@ where
 impl<T> Into<NonNull<T>> for Ptr<T> {
     /// Need to use Into because of orphan rules
     fn into(mut self) -> NonNull<T> {
-        // Use .take to ensure that the `*mut T` doesn't get dropped. 
+        // Use .take to ensure that the `*mut T` doesn't get dropped.
         if let Some(nn) = self.inner.take() {
             nn
         } else {

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -172,7 +172,7 @@ where
 
 impl<T> fmt::Pointer for Ptr<T> {
     /// Formats [`Ptr<T>`] as a pointer value (ie, hexadecimal)
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(ref nn) = &self.inner {
             write!(f, "{:p}", nn)
         } else {

--- a/src/types.rs
+++ b/src/types.rs
@@ -556,25 +556,25 @@ impl AsRef<i32> for Int {
 }
 
 impl fmt::UpperHex for Int {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:X}", self.0)
     }
 }
 
 impl fmt::LowerHex for Int {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:x}", self.0)
     }
 }
 
 impl fmt::Octal for Int {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:o}", self.0)
     }
 }
 
 impl fmt::Binary for Int {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:b}", self.0)
     }
 }
@@ -624,25 +624,25 @@ impl AsRef<u32> for UInt {
 }
 
 impl fmt::UpperHex for UInt {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:X}", self.0)
     }
 }
 
 impl fmt::LowerHex for UInt {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:x}", self.0)
     }
 }
 
 impl fmt::Octal for UInt {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:o}", self.0)
     }
 }
 
 impl fmt::Binary for UInt {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:b}", self.0)
     }
 }
@@ -693,25 +693,25 @@ impl AsRef<i32> for SCode {
 }
 
 impl fmt::UpperHex for SCode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "0X{:X}", self.0)
     }
 }
 
 impl fmt::LowerHex for SCode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "0x{:x}", self.0)
     }
 }
 
 impl fmt::Octal for SCode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:o}", self.0)
     }
 }
 
 impl fmt::Binary for SCode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:b}", self.0)
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,7 +15,7 @@ use std::convert::TryFrom;
 #[cfg(feature = "impl_tryfrom")]
 use std::num::TryFromIntError;
 
-use failure;
+use std::error::Error;
 
 use rust_decimal::Decimal;
 
@@ -29,7 +29,7 @@ use super::errors::{
 pub trait TryConvert<T, F>
 where
     Self: Sized,
-    F: failure::Fail,
+    F: Error,
 {
     /// Utility method which can fail.
     fn try_convert(val: T) -> Result<Self, F>;
@@ -38,7 +38,7 @@ where
 impl<T, F> TryConvert<T, F> for T
 where
     T: From<T>,
-    F: failure::Fail,
+    F: Error,
 {
     /// Blanket TryConvert implementation wherever a From<T> is implemented for T. (Which is all types.)
     /// This avoids repetitive code. The compiler monomorphizes the code for F.

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -306,7 +306,7 @@ pub(crate) mod private {
             }
         }
     }
-    impl<VD> VariantAccess<VD> for Box<VariantWrapper>
+    impl<VD> VariantAccess<VD> for Box<dyn VariantWrapper>
     where
         VD: PtrDestructor<VARIANT>,
     {
@@ -757,16 +757,16 @@ where
     }
 }
 
-impl<D> TryConvert<Box<VariantWrapper<D>>, ElementError> for Ptr<VARIANT, D>
+impl<D> TryConvert<Box<dyn VariantWrapper<D>>, ElementError> for Ptr<VARIANT, D>
 where
     D: PtrDestructor<VARIANT>,
 {
-    fn try_convert(vw: Box<VariantWrapper<D>>) -> Result<Ptr<VARIANT, D>, ElementError> {
+    fn try_convert(vw: Box<dyn VariantWrapper<D>>) -> Result<Ptr<VARIANT, D>, ElementError> {
         Ok(vw.into_var()?)
     }
 }
 
-impl<D> TryConvert<Ptr<VARIANT, D>, ElementError> for Box<VariantWrapper<D>>
+impl<D> TryConvert<Ptr<VARIANT, D>, ElementError> for Box<dyn VariantWrapper<D>>
 where
     D: PtrDestructor<VARIANT>,
 {
@@ -1005,7 +1005,7 @@ mod test {
     fn varwrapper() {
         use crate::SafeArrayExt;
         use std::vec::IntoIter;
-        let v: Vec<Box<VariantWrapper>> = vec![
+        let v: Vec<Box<dyn VariantWrapper>> = vec![
             Box::new(Variants::Byte(-67)),
             Box::new(Variants::UShort(10000)),
         ];

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -379,7 +379,6 @@ pub(crate) mod private {
         }
         fn into_var(_inner: Self::Field, _n1: &mut VARIANT_n1, _n3: &mut VARIANT_n3) {}
     }
-
 }
 
 /// Container for variant-compatible types. Wrap them with this


### PR DESCRIPTION
Hey there! This is an unsolicited PR updating some underpinnings of this crate. I decided to do it while running into issues updating the error handling for the @NZXTCorp's CAM project, where `std::error::Error` (now the de-facto point of error interoperability in current Rust) is an important part of the story. In order to resolve this, I've swapped out the usage of `failure` (which implies a certain set of tradeoffs for an abstract error type the Rust community didn't reach consensus on) for `thiserror`, which is much more interoperable with Rust's current ecosystem nowadays.

I've also included some other updates, like a migration to Rust 2018, that you may not care for. I'm not sure what the MSRV for this crate is, if there is one, but it may affect people using Rust older than 1.34.

See individual commits for more details. I've tried to be fairly detailed, but I'm definitely not writing any significant prose yet.